### PR TITLE
Added mfa code input to login form

### DIFF
--- a/components/form/Login.vue
+++ b/components/form/Login.vue
@@ -21,6 +21,14 @@
 			@valid="form.password.valid = $event"
 		/>
 
+		<InputOTP
+			v-if="needMFA"
+			label="Inputs.MFACode"
+			v-model="form.mfa_code.value"
+			@valid="form.mfa_code.valid = needMFA ? $event : true"
+			:rules="form.mfa_code.rules"
+		/>
+
 		<InputBtn
 			:loading="form.submitting"
 			class="self-end"
@@ -58,6 +66,14 @@ export default defineComponent({
 				valid: false,
 				value: '',
 				rules: [(v: string) => !!v || 'Error.InputEmpty_Inputs.Password'],
+			},
+			mfa_code: {
+				valid: true,
+				value: '',
+				rules: [
+					(v: string) => !!v || 'Error.InputEmpty_Inputs.MFACode',
+					(v: string) => v.length >= 6 || 'Error.InputMinLength_6',
+				],
 			},
 			submitting: false,
 			validate: () => {
@@ -133,15 +149,31 @@ export default defineComponent({
 			router.push(`/dashboard`);
 		}
 
+		const needMFA = ref(false);
+
 		function errorHandler(res: any) {
-			openSnackbar('error', res?.detail ?? '');
+			let msg = res?.detail ?? '';
+
+			let isMFA = msg == 'Error.InvalidCode';
+
+			if (!!isMFA && !!needMFA.value) {
+				openSnackbar('error', msg);
+			}
+
+			if (isMFA) {
+				needMFA.value = true;
+			} else {
+				openSnackbar('error', msg);
+			}
 		}
+
 
 		return {
 			form,
 			onclickSubmitForm,
 			refForm,
 			t,
+			needMFA,
 		};
 	},
 });

--- a/locales/de.json
+++ b/locales/de.json
@@ -127,7 +127,8 @@
 		"SkillName": "Name",
 		"SkillIcon": "Icon",
 		"SkillDependencies": "Dependencies",
-		"SkillCourses": "Courses"
+		"SkillCourses": "Courses",
+		"MFACode": "6-stelliger MFA-Code"
 	},
 	"Buttons": {
 		"Safe": "Safe",

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -127,7 +127,8 @@
 		"SkillName": "Name",
 		"SkillIcon": "Icon",
 		"SkillDependencies": "Dependencies",
-		"SkillCourses": "Courses"
+		"SkillCourses": "Courses",
+		"MFACode": "MFA 6 digit Code"
 	},
 	"Buttons": {
 		"Safe": "Safe",


### PR DESCRIPTION
The login form of the admin dashboard does not allow users who have multi-factor authentication to log in. This change causes the input for the MFA code to be displayed as for the bootstrap.academy frontend, if it is needed.