### PR TITLE
Treat avatar_url as optional

### DIFF
--- a/components/Avatar.vue
+++ b/components/Avatar.vue
@@ -1,0 +1,49 @@
+<template>
+  <svg
+    class="rounded-full bg-tertiary text-heading"
+    viewBox="0 0 40 40"
+    role="img"
+    :aria-label="alt"
+  >
+    <text
+      v-if="initials"
+      x="20"
+      y="20"
+      text-anchor="middle"
+      dominant-baseline="central"
+      font-size="16"
+      font-weight="600"
+      fill="currentColor"
+    >
+      {{ initials }}
+    </text>
+  </svg>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  props: {
+    // Display name the initials are taken from.
+    name: { type: String, default: '' },
+    // Alt text of the generated avatar.
+    alt: { type: String, default: 'user avatar' },
+  },
+  setup(props) {
+    const initials = computed(() => {
+      const words = props.name.trim().split(/\s+/).filter(Boolean);
+      if (!words.length) return '';
+
+      const first = [...words[0]][0] ?? '';
+      const last =
+        words.length > 1 ? ([...words[words.length - 1]][0] ?? '') : '';
+      return (first + last).toLocaleUpperCase();
+    });
+
+    return { initials };
+  },
+});
+</script>
+
+<style scoped></style>

--- a/components/appUsers/Profile.vue
+++ b/components/appUsers/Profile.vue
@@ -7,13 +7,12 @@
 				<h3>{{ item.label }}</h3>
 
 				<div
-					v-if="item.src"
+					v-if="item.avatar !== undefined"
 					class="flex gap-2 md:gap-4 items-center max-w-[350px]"
 				>
-					<img
-						:src="item.src"
-						alt=""
-						class="h-5 w-5 md:h-10 md:w-10 object-contain rounded-full"
+					<Avatar
+						:name="item.avatar"
+						class="h-5 w-5 md:h-10 md:w-10 flex-shrink-0"
 					/>
 					<p class="clamp line-1 text-body-1 text-heading">
 						{{ item.value }}
@@ -78,7 +77,7 @@ export default defineComponent({
         {
           label: 'Name',
           value: props.data?.name ?? '',
-          src: props.data?.avatar_url ?? '',
+          avatar: props.data?.display_name ?? props.data?.name ?? '',
         },
         {
           label: 'Display Name',

--- a/components/appUsers/Table.vue
+++ b/components/appUsers/Table.vue
@@ -7,10 +7,9 @@
   >
     <template #display_name="{ item }">
       <div class="flex gap-2 md:gap-4 items-center">
-        <img
-          :src="item.avatar_url"
-          alt=""
-          class="h-5 w-5 md:h-10 md:w-10 object-contain rounded-full"
+        <Avatar
+          :name="item.display_name"
+          class="h-5 w-5 md:h-10 md:w-10 flex-shrink-0"
         />
         <div class="overflow-hidden w-full max-w-[325px]">
           <p class="truncate text-ellipsis text-body-2">


### PR DESCRIPTION
## What

The auth service now returns `avatar_url: null` for every user, so the two places
that bound it to an `<img>` src render an empty image.

## Changes

- `components/Avatar.vue` (new): inline SVG rendering the user's initials on a
  neutral circle, mirroring the component the frontend uses.
- `components/appUsers/Table.vue`: the user column renders `<Avatar>` instead of
  `<img :src="item.avatar_url">`.
- `components/appUsers/Profile.vue`: the name row renders `<Avatar>` instead of
  `<img :src="item.src">`; the list entry carries the display name to derive the
  initials from rather than the avatar URL.

`avatar_url` is no longer read anywhere in this repository, and no remote image is
requested for a user any more.

## Verification

- `npm run lint`
- `bash build.sh` (`nuxt generate`) — 15 routes prerendered, no errors

Co-Authored-By: Claude <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
