### PR TITLE
chore(users): remove the newsletter column, filter and account card

### DIFF
--- a/components/appUsers/Account.vue
+++ b/components/appUsers/Account.vue
@@ -19,14 +19,6 @@
 		<hr />
 
 		<article>
-			<h3>{{ newsletter.label }}</h3>
-			<CheckCircleIcon v-if="newsletter.value" class="icon text-success" />
-			<XCircleIcon v-else class="icon text-error" />
-		</article>
-
-		<hr />
-
-		<article>
 			<h3>
 				{{ enabled.label }}
 				<PencilSquareIcon class="pencil-icon" @click="enabled.onclick()" />
@@ -174,13 +166,6 @@ export default defineComponent({
       };
     });
 
-    const newsletter = computed(() => {
-      return {
-        label: 'Newsletter',
-        value: props.data?.newsletter ?? false,
-      };
-    });
-
     const registration = computed(() => {
       let { date, month, year } = convertTimestampToDate(
         props.data?.registration ?? ''
@@ -207,7 +192,6 @@ export default defineComponent({
       isMFA,
       verified,
       role,
-      newsletter,
       registration,
       last_login,
       coinsDialog,

--- a/components/appUsers/Table.vue
+++ b/components/appUsers/Table.vue
@@ -49,11 +49,6 @@
       <XMarkIcon v-else class="icon text-error" />
     </template>
 
-    <template #newsletter="{ item }">
-      <CheckIcon v-if="item.newsletter" class="icon text-success" />
-      <XMarkIcon v-else class="icon text-error" />
-    </template>
-
     <template #enabled="{ item }">
       <CheckIcon v-if="item.enabled" class="icon text-success" />
       <XMarkIcon v-else class="icon text-error" />
@@ -184,10 +179,6 @@ export default {
         {
           label: "Headings.MFA",
           key: "mfa_enabled",
-        },
-        {
-          label: "Headings.Newsletter",
-          key: "newsletter",
         },
         {
           label: "Headings.Enabled",

--- a/composables/fetch.js
+++ b/composables/fetch.js
@@ -122,8 +122,6 @@ const onResponseError = async ({ request, options, response }) => {
     response._data.detail = "Error.InvalidVerificationCode";
   } else if (details.includes("email already verified")) {
     response._data.detail = "Error.EmailAlreadyVerified";
-  } else if (details.includes("newsletter already subscribed")) {
-    response._data.detail = "Error.NewsletterAlreadySubscribed";
   } else if (details.includes("mfa already enabled")) {
     response._data.detail = "Error.MFAAlreadyEnabled";
   } else if (details.includes("mfa not initialized")) {

--- a/locales/de.json
+++ b/locales/de.json
@@ -43,8 +43,6 @@
 		"NotVerified": "Email nicht verifiziert",
 		"MFA": "2FA Aktiviert",
 		"NOMFA": "2FA Deaktiviert",
-		"Newsletter": "Newsletter abonniert",
-		"NoNewsletter": "Newsletter nicht abonniert",
 		"Enabled": "Enabled",
 		"EnabledUser": "Enabled User",
 		"UserDisabled": "Gebannte User",

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -46,8 +46,6 @@
 		"NotVerified": "Email not Verified",
 		"MFA": "MFA Enabled",
 		"NOMFA": "MFA Disabled",
-		"Newsletter": "Newsletter enabled",
-		"NoNewsletter": "Newsletter disabled",
 		"UserEnabled": "Normal User",
 		"UserDisabled": "Banned User",
 		"Balance": "Balance",

--- a/pages/dashboard/skill-tree/[rootSkill]/sub-skills.vue
+++ b/pages/dashboard/skill-tree/[rootSkill]/sub-skills.vue
@@ -91,7 +91,6 @@ export default {
         admin: false,
         mfa_enabled: false,
         email_verified: false,
-        newsletter: false,
       }
     );
 
@@ -134,10 +133,6 @@ export default {
         label: 'Headings.Verified',
         value: 'email_verified',
       },
-      {
-        label: 'Headings.Newsletter',
-        value: 'newsletter',
-      },
     ];
 
     function onSelectedOption(option: string) {
@@ -146,7 +141,6 @@ export default {
         admin: option == 'admin',
         mfa_enabled: option == 'mfa_enabled',
         email_verified: option == 'email_verified',
-        newsletter: option == 'newsletter',
       });
     }
 

--- a/pages/dashboard/skill-tree/index.vue
+++ b/pages/dashboard/skill-tree/index.vue
@@ -78,7 +78,6 @@ export default {
         admin: false,
         mfa_enabled: false,
         email_verified: false,
-        newsletter: false,
       }
     );
 
@@ -121,10 +120,6 @@ export default {
         label: 'Headings.Verified',
         value: 'email_verified',
       },
-      {
-        label: 'Headings.Newsletter',
-        value: 'newsletter',
-      },
     ];
 
     function onSelectedOption(option: string) {
@@ -133,7 +128,6 @@ export default {
         admin: option == 'admin',
         mfa_enabled: option == 'mfa_enabled',
         email_verified: option == 'email_verified',
-        newsletter: option == 'newsletter',
       });
     }
 

--- a/pages/dashboard/users/index.vue
+++ b/pages/dashboard/users/index.vue
@@ -201,8 +201,7 @@ export default {
         new CheckOption(USER_LOCALES.USER_ENABLED),
         new CheckOption(USER_LOCALES.USER_ADMIN),
         new CheckOption(USER_LOCALES.USER_MFA),
-        new CheckOption(USER_LOCALES.USER_EMAIL_VERIFIED),
-        new CheckOption(USER_LOCALES.USER_NEWSLETTER)
+        new CheckOption(USER_LOCALES.USER_EMAIL_VERIFIED)
       );
     };
 
@@ -220,9 +219,6 @@ export default {
           break;
         case USER_LOCALES.USER_EMAIL_VERIFIED:
           getUserRequestBody.email_verified = option.value;
-          break;
-        case USER_LOCALES.USER_NEWSLETTER:
-          getUserRequestBody.newsletter = option.value;
           break;
         }
       });
@@ -262,14 +258,6 @@ export default {
       {
         label: 'Headings.NotVerified',
         value: USERSORT.NOTEMAILVERIFIED,
-      },
-      {
-        label: 'Headings.Newsletter',
-        value: USERSORT.NEWSLETTER,
-      },
-      {
-        label: 'Headings.NoNewsletter',
-        value: USERSORT.NOTNEWSLETTER,
       },
     ];
 
@@ -314,16 +302,6 @@ export default {
       case USERSORT.NOTEMAILVERIFIED:
         getUserRequestBody.clearFilters();
         getUserRequestBody.email_verified = false;
-        userSearch();
-        break;
-      case USERSORT.NEWSLETTER:
-        getUserRequestBody.clearFilters();
-        getUserRequestBody.newsletter = true;
-        userSearch();
-        break;
-      case USERSORT.NOTNEWSLETTER:
-        getUserRequestBody.clearFilters();
-        getUserRequestBody.newsletter = false;
         userSearch();
         break;
       }

--- a/types/userTypes.ts
+++ b/types/userTypes.ts
@@ -13,7 +13,6 @@ export class User {
   mfa_enabled: boolean = false;
   description: string = '';
   tags: string[] = [];
-  newsletter: boolean = false;
 }
 
 export class UserFilter {
@@ -22,7 +21,6 @@ export class UserFilter {
   admin?: boolean = false;
   mfa_enabled?: boolean = false;
   email_verified?: boolean = false;
-  newsletter?: boolean = false;
 }
 
 export class UserSearchRequestBody {
@@ -34,7 +32,6 @@ export class UserSearchRequestBody {
   admin: boolean | undefined = undefined;
   mfa_enabled: boolean | undefined = undefined;
   email_verified: boolean | undefined = undefined;
-  newsletter: boolean | undefined = undefined;
 
   clearSearch(){
     this.name = undefined;
@@ -46,7 +43,6 @@ export class UserSearchRequestBody {
     this.admin = undefined;
     this.mfa_enabled = undefined;
     this.email_verified = undefined;
-    this.newsletter = undefined;
   }
 }
 
@@ -65,8 +61,6 @@ export enum USERSORT{
     NOMFA = 'nomfa',
     EMAILVERIFIED = 'emailverified',
     NOTEMAILVERIFIED = 'notemailverified',
-    NEWSLETTER = 'newsletter',
-    NOTNEWSLETTER = 'notnewsletter',
 }
 
 export enum USER_LOCALES{
@@ -74,5 +68,4 @@ export enum USER_LOCALES{
     USER_ADMIN = 'Headings.Admin',
     USER_MFA = 'Headings.MFA',
     USER_EMAIL_VERIFIED = 'Headings.Verified',
-    USER_NEWSLETTER = 'Headings.Newsletter',
 }


### PR DESCRIPTION
Follow-up to backend #725, which removes the `newsletter` field from the user model and the `newsletter` filter from `GET /auth/users`.

Without this change the dashboard would keep showing a "Newsletter" column and account-card entry that always reads as ✗, and the newsletter sort/search filters would send a query parameter the backend ignores, silently returning unfiltered results.

Removed: the users-table column and cell template, the account card entry, `USERSORT.NEWSLETTER` / `NOTNEWSLETTER` and the `USER_NEWSLETTER` search option, the `newsletter` fields on the user and filter types, the "newsletter already subscribed" error mapping, the two `Headings` locale strings, and the copy-pasted `newsletter` entry in the skill-tree filter shape.

`npm run lint` and `bash build.sh` pass locally.

Co-Authored-By: Claude <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
