### PR TITLE
feat(login): tell administrators to set up two factor authentication

### DIFF
--- a/components/form/Login.vue
+++ b/components/form/Login.vue
@@ -119,6 +119,7 @@ export default defineComponent({
     // ============================================================= Checks
     const router = useRouter();
     const user: Ref<any> = useUser();
+    const session: Ref<any> = useSession();
     // ============================================================= functions
     async function onclickSubmitForm() {
       if (form.validate()) {
@@ -136,6 +137,14 @@ export default defineComponent({
         // checking is logged in user is admin or not
         if (Boolean(success) && user.value.admin == false) {
           errorHandler({ detail: 'Error.NotAuthorized' });
+          setStates(null);
+          return;
+        }
+
+        // the backend only grants administrative privileges to sessions that
+        // were authenticated with a second factor
+        if (Boolean(success) && session.value?.mfa_verified !== true) {
+          errorHandler({ detail: 'Error.AdminMFARequired' });
           setStates(null);
           return;
         }

--- a/composables/fetch.js
+++ b/composables/fetch.js
@@ -116,6 +116,8 @@ const onResponseError = async ({ request, options, response }) => {
     response._data.detail = "Error.MessageNotSubmitted";
   } else if (details.includes("user not found")) {
     response._data.detail = "Error.UserNotFound";
+  } else if (details.includes("admin mfa required")) {
+    response._data.detail = "Error.AdminMFARequired";
   } else if (details.includes("permission denied")) {
     response._data.detail = "Error.PermissionDenied";
   } else if (details.includes("invalid verification code")) {

--- a/locales/de.json
+++ b/locales/de.json
@@ -260,6 +260,7 @@
 		"RecaptchaFailed": "Ihr Recaptcha ist fehlgeschlagen.",
 		"AccountNotVerified": "Bitte verifizieren Sie Ihr Konto, um fortzufahren.",
 		"UserNotFound": "Benutzer wurde nicht gefunden",
+		"AdminMFARequired": "Administrationskonten benötigen eine Zwei-Faktor-Authentisierung. Richten Sie unter bootstrap.academy/account/mfa/initialize einen Authenticator ein und melden Sie sich anschließend mit Ihrem Code an.",
 		"PermissionDenied": "Sie haben keine Berechtigung für diese Aktion",
 		"InvalidVerificationCode": "Dieser Bestätigungscode ist ungültig. Bitte verwenden Sie einen gültigen.",
 		"EmailAlreadyVerified": "Diese E-Mail ist bereits verifiziert",

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -263,6 +263,7 @@
 		"RecaptchaFailed": "Your recaptcha has failed.",
 		"AccountNotVerified": "Please verify your account in order to move forward.",
 		"UserNotFound": "User was not found",
+		"AdminMFARequired": "Administrator accounts require two factor authentication. Set up an authenticator at bootstrap.academy/account/mfa/initialize and log in with your code afterwards.",
 		"PermissionDenied": "You do not have permission for this action",
 		"InvalidVerificationCode": "This verification code is invalid. Please use a valid one.",
 		"EmailAlreadyVerified": "This email is already verified",


### PR DESCRIPTION
The backend only grants administrative privileges to sessions that were established with a verified TOTP code (Bootstrap-Academy/backend#732). The dashboard already asks for the code when the backend reports `Invalid code`, but an administrator who has never set up an authenticator used to land on the dashboard with a session that every administrative endpoint refuses.

* `components/form/Login.vue` checks `session.mfa_verified` after a successful login, next to the existing `admin` check. Without it the session is discarded and the snackbar explains where to set up an authenticator.
* `composables/fetch.js` maps a `Admin MFA required` response from any endpoint to `Error.AdminMFARequired`.
* German and English wording for the new message.

Administrators who already use an authenticator are unaffected: the backend answers the password-only login with `Invalid code`, the form shows the OTP input as before, and the session that comes back is MFA verified.

Verified locally: `npm run lint` and `bash build.sh` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)